### PR TITLE
Fix TypeScript support & runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "homepage": "https://github.com/Corsinvest/cv4pve-api-javascript#readme",
   "devDependencies": {
     "typescript": "^5.3.3"
+  },
+  "dependencies": {
+    "debug": "^4.3.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "files": [
     "src",
-    "dest",
+    "dist",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
- Fixed `dist` typo in `package.json` - which was stopping NPM from including TypeScript's output in the packaged tarball.
- Added `debug` as a dependency due to it being a requirement at runtime [here](https://github.com/Corsinvest/cv4pve-api-javascript/blob/main/src/index.js#L156).